### PR TITLE
Singularize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: php
 php:
-    - 5.5
     - 5.6
     - 7.0
+    - 7.1
+    - 7.2
+    - 7.3
     - hhvm
     - hhvm-nightly
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "nette/database": ">=2.4.0",
     "nette/php-generator": ">=2.4.0",
     "nette/utils": ">=2.4.0",
-    "doctrine/inflector": ">=1.3"
+    "doctrine/inflector": ">=1.0"
   },
   "require-dev": {
     "nette/tester": "~1.5.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "php": ">= 5.5",
     "nette/database": ">=2.4.0",
     "nette/php-generator": ">=2.4.0",
-    "nette/utils": ">=2.4.0"
+    "nette/utils": ">=2.4.0",
+    "doctrine/inflector": ">=1.3"
   },
   "require-dev": {
     "nette/tester": "~1.5.0",

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
   ],
   "require": {
     "php": ">= 5.5",
-    "nette/database": ">=2.3.0",
-    "nette/php-generator": ">=2.3.0",
-    "nette/utils": ">=2.3.0"
+    "nette/database": "2.4.0",
+    "nette/php-generator": "2.4.0",
+    "nette/utils": "2.4.0"
   },
   "require-dev": {
     "nette/tester": "~1.5.0",

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
   ],
   "require": {
     "php": ">= 5.5",
-    "nette/database": "2.4.0",
-    "nette/php-generator": "2.4.0",
-    "nette/utils": "2.4.0"
+    "nette/database": ">=2.4.0",
+    "nette/php-generator": ">=2.4.0",
+    "nette/utils": ">=2.4.0"
   },
   "require-dev": {
     "nette/tester": "~1.5.0",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": ">= 5.5",
+    "php": ">= 5.6",
     "nette/database": ">=2.4.0",
     "nette/php-generator": ">=2.4.0",
     "nette/utils": ">=2.4.0",

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -30,29 +30,34 @@ class Config implements \ArrayAccess
         'nextras.orm.class.mapper' => 'Nextras\Orm\Mapper\Mapper',
         // ORM
         'orm.namespace' => NULL,
+		'orm.singularize' => FALSE,
         // Entity
         'entity.folder' => NULL,
         'entity.namespace' => NULL,
         'entity.extends' => NULL,
         'entity.name.suffix' => NULL,
+		'entity.name.singularize' => FALSE,
         'entity.filename.suffix' => NULL,
         // Repository
         'repository.folder' => NULL,
         'repository.namespace' => NULL,
         'repository.extends' => NULL,
         'repository.name.suffix' => NULL,
+		'repository.name.singularize' => FALSE,
         'repository.filename.suffix' => NULL,
         // Mapper
         'mapper.folder' => NULL,
         'mapper.namespace' => NULL,
         'mapper.extends' => NULL,
         'mapper.name.suffix' => NULL,
+		'mapper.name.singularize' => FALSE,
         'mapper.filename.suffix' => NULL,
         // Facade
         'facade.folder' => NULL,
         'facade.namespace' => NULL,
         'facade.extends' => NULL,
         'facade.name.suffix' => NULL,
+		'facade.name.singularize' => FALSE,
         'facade.filename.suffix' => NULL,
     ];
 

--- a/src/Config/Impl/SeparateConfig.php
+++ b/src/Config/Impl/SeparateConfig.php
@@ -24,29 +24,34 @@ class SeparateConfig extends Config
         'nextras.orm.class.mapper' => 'Nextras\Orm\Mapper\Mapper',
         // ORM
         'orm.namespace' => NULL,
+		'orm.singularize' => FALSE,
         // Entity
         'entity.folder' => 'Entity',
         'entity.namespace' => 'App\Model\Entity',
         'entity.extends' => 'App\Model\Entity\AbstractEntity',
         'entity.name.suffix' => NULL,
+		'entity.name.singularize' => FALSE,
         'entity.filename.suffix' => NULL,
         // Repository
         'repository.folder' => 'Repository',
         'repository.namespace' => 'App\Model\Repository',
         'repository.extends' => 'App\Model\Repository\AbstractRepository',
         'repository.name.suffix' => 'Repository',
+		'repository.name.singularize' => FALSE,
         'repository.filename.suffix' => 'Repository',
         // Mapper
         'mapper.folder' => 'Mapper',
         'mapper.namespace' => 'App\Model\Mapper',
         'mapper.extends' => 'App\Model\Mapper\AbstractMapper',
         'mapper.name.suffix' => 'Mapper',
+		'mapper.name.singularize' => FALSE,
         'mapper.filename.suffix' => 'Mapper',
         // Facade
         'facade.folder' => 'Facade',
         'facade.namespace' => 'App\Model\Facade',
         'facade.extends' => 'App\Model\Facade\AbstractFacade',
         'facade.name.suffix' => 'Facade',
+		'facade.name.singularize' => FALSE,
         'facade.filename.suffix' => 'Facade',
     ];
 

--- a/src/Config/Impl/TogetherConfig.php
+++ b/src/Config/Impl/TogetherConfig.php
@@ -24,29 +24,34 @@ class TogetherConfig extends Config
         'nextras.orm.class.mapper' => 'Nextras\Orm\Mapper\Mapper',
         // ORM
         'orm.namespace' => 'App\Model',
+		'orm.singularize' => FALSE,
         // Entity
         'entity.folder' => NULL,
         'entity.namespace' => 'App\Model',
         'entity.extends' => 'App\Model\Entity\AbstractEntity',
         'entity.name.suffix' => NULL,
+		'entity.name.singularize' => FALSE,
         'entity.filename.suffix' => NULL,
         // Repository
         'repository.folder' => NULL,
         'repository.namespace' => 'App\Model',
         'repository.extends' => 'App\Model\AbstractRepository',
         'repository.name.suffix' => 'Repository',
+		'repository.name.singularize' => FALSE,
         'repository.filename.suffix' => 'Repository',
         // Mapper
         'mapper.folder' => NULL,
         'mapper.namespace' => 'App\Model',
         'mapper.extends' => 'App\Model\AbstractMapper',
         'mapper.name.suffix' => 'Mapper',
+		'mapper.name.singularize' => FALSE,
         'mapper.filename.suffix' => 'Mapper',
         // Facade
         'facade.folder' => NULL,
         'facade.namespace' => 'App\Model',
         'facade.extends' => 'App\Model\AbstractFacade',
         'facade.name.suffix' => 'Facade',
+		'facade.name.singularize' => FALSE,
         'facade.filename.suffix' => 'Facade',
     ];
 

--- a/src/Generator/Entity/Decorator/ColumnDocumentor.php
+++ b/src/Generator/Entity/Decorator/ColumnDocumentor.php
@@ -79,7 +79,7 @@ class ColumnDocumentor implements IDecorator
         }
 
         // Append phpDoc to class
-        $class->addDocument((string)$column->getPhpDoc());
+        $class->addComment((string)$column->getPhpDoc());
     }
 
     /**

--- a/src/Generator/Mapper/MapperGenerator.php
+++ b/src/Generator/Mapper/MapperGenerator.php
@@ -42,6 +42,11 @@ class MapperGenerator extends AbstractGenerator
                 $class->setExtends($extends);
             }
 
+			$class->addMethod('getTableName')
+				->setBody('return \'' . $table->getName() . '\';')
+				->setReturnType('string')
+				->setVisibility('public');
+
             // Save file
             $this->generateFile($this->resolver->resolveMapperFilename($table), (string)$namespace);
         }

--- a/src/Generator/Repository/RepositoryGenerator.php
+++ b/src/Generator/Repository/RepositoryGenerator.php
@@ -50,7 +50,7 @@ class RepositoryGenerator extends AbstractGenerator
 
             $entityName = $this->entityResolver->resolveEntityName($table);
             $class->addMethod("getEntityClassNames")
-				->addDocument("@return array")
+				->addComment("@return array")
 				->setVisibility('public')
 				->setStatic(true)
 				->addBody("return [$entityName::class];");

--- a/src/Generator/Repository/RepositoryGenerator.php
+++ b/src/Generator/Repository/RepositoryGenerator.php
@@ -47,7 +47,7 @@ class RepositoryGenerator extends AbstractGenerator
                 $namespace->addUse($extends);
                 $class->setExtends($extends);
             }
-
+            $namespace->addUse($this->entityResolver->resolveEntityNamespace($table) . '\\' . $this->entityResolver->resolveEntityName($table));
             $entityName = $this->entityResolver->resolveEntityName($table);
             $class->addMethod("getEntityClassNames")
 				->addComment("@return array")

--- a/src/Resolver/Impl/SimpleResolver.php
+++ b/src/Resolver/Impl/SimpleResolver.php
@@ -2,6 +2,7 @@
 
 namespace Minetro\Normgen\Resolver\Impl;
 
+use Doctrine\Common\Inflector\Inflector;
 use Minetro\Normgen\Config\Config;
 use Minetro\Normgen\Entity\Table;
 use Minetro\Normgen\Resolver\IEntityResolver;
@@ -54,8 +55,13 @@ abstract class SimpleResolver implements IEntityResolver, IRepositoryResolver, I
      * @param Table $table
      * @return string
      */
-    protected function table(Table $table)
+    protected function table(Table $table, $singularize = FALSE)
     {
-        return $this->normalize(ucfirst($table->getName()));
+        $name = $this->normalize(ucfirst($table->getName()));
+
+        if ($singularize) {
+				$name = Inflector::singularize($name);
+			}
+        return $name;
     }
 }

--- a/src/Resolver/Impl/SimpleSeparateResolver.php
+++ b/src/Resolver/Impl/SimpleSeparateResolver.php
@@ -2,6 +2,7 @@
 
 namespace Minetro\Normgen\Resolver\Impl;
 
+use Doctrine\Common\Inflector\Inflector;
 use Minetro\Normgen\Entity\Table;
 use Minetro\Normgen\Resolver\IFilenameResolver;
 
@@ -14,7 +15,7 @@ class SimpleSeparateResolver extends SimpleResolver
      */
     public function resolveEntityName(Table $table)
     {
-        return $this->normalize(ucfirst($table->getName()) . $this->config->get('entity.name.suffix'));
+    	return $this->resolveNameFor('entity', $table);
     }
 
     /**
@@ -32,7 +33,7 @@ class SimpleSeparateResolver extends SimpleResolver
      */
     public function resolveEntityFilename(Table $table)
     {
-        return $this->config->get('entity.folder') . DIRECTORY_SEPARATOR . $this->normalize(ucfirst($table->getName()) . $this->config->get('entity.filename.suffix')) . '.' . IFilenameResolver::PHP_EXT;
+		return $this->resolveFilenameFor('entity', $table);
     }
 
     /**
@@ -41,7 +42,7 @@ class SimpleSeparateResolver extends SimpleResolver
      */
     public function resolveRepositoryName(Table $table)
     {
-        return $this->normalize(ucfirst($table->getName()) . $this->config->get('repository.name.suffix'));
+		return $this->resolveNameFor('repository', $table);
     }
 
     /**
@@ -59,7 +60,7 @@ class SimpleSeparateResolver extends SimpleResolver
      */
     public function resolveRepositoryFilename(Table $table)
     {
-        return $this->config->get('repository.folder') . DIRECTORY_SEPARATOR . $this->normalize(ucfirst($table->getName()) . $this->config->get('repository.filename.suffix')) . '.' . IFilenameResolver::PHP_EXT;
+		return $this->resolveFilenameFor('repository', $table);
     }
 
     /**
@@ -68,7 +69,7 @@ class SimpleSeparateResolver extends SimpleResolver
      */
     public function resolveMapperName(Table $table)
     {
-        return $this->normalize(ucfirst($table->getName()) . $this->config->get('mapper.name.suffix'));
+		return $this->resolveNameFor('mapper', $table);
     }
 
     /**
@@ -77,7 +78,7 @@ class SimpleSeparateResolver extends SimpleResolver
      */
     public function resolveMapperFilename(Table $table)
     {
-        return $this->config->get('mapper.folder') . DIRECTORY_SEPARATOR . $this->normalize(ucfirst($table->getName()) . $this->config->get('mapper.filename.suffix')) . '.' . IFilenameResolver::PHP_EXT;
+		return $this->resolveFilenameFor('mapper', $table);
     }
 
     /**
@@ -95,7 +96,7 @@ class SimpleSeparateResolver extends SimpleResolver
      */
     public function resolveFacadeName(Table $table)
     {
-        return $this->normalize(ucfirst($table->getName()) . $this->config->get('facade.name.suffix'));
+    	return $this->resolveNameFor('facade', $table);
     }
 
     /**
@@ -113,7 +114,36 @@ class SimpleSeparateResolver extends SimpleResolver
      */
     public function resolveFacadeFilename(Table $table)
     {
-        return $this->config->get('facade.folder') . DIRECTORY_SEPARATOR . $this->normalize(ucfirst($table->getName()) . $this->config->get('facade.filename.suffix')) . '.' . IFilenameResolver::PHP_EXT;
+    	return $this->resolveFilenameFor('facade', $table);
     }
 
+	/**
+	 * @param $tpe
+	 * @param Table $table
+	 * @return string
+	 */
+    protected function resolveFilenameFor($type, Table $table)
+	{
+		$name = $this->normalize(ucfirst($table->getName()));
+		if($this->config->get($type . '.name.singularize')) {
+			$name = Inflector::singularize($name);
+		}
+		$name .= $this->config->get($type . '.filename.suffix');
+		return $this->config->get($type . '.folder') . DIRECTORY_SEPARATOR . $name . '.' . IFilenameResolver::PHP_EXT;
+	}
+
+	/**
+	 * @param $type
+	 * @param Table $table
+	 * @return string
+	 */
+	protected function resolveNameFor($type, Table $table)
+	{
+		$name = $this->normalize(ucfirst($table->getName()));
+		if($this->config->get($type . '.name.singularize')) {
+			$name = Inflector::singularize($name);
+		}
+		$name .= $this->config->get($type . '.name.suffix');
+		return $name;
+	}
 }

--- a/src/Resolver/Impl/SimpleTogetherResolver.php
+++ b/src/Resolver/Impl/SimpleTogetherResolver.php
@@ -2,6 +2,7 @@
 
 namespace Minetro\Normgen\Resolver\Impl;
 
+use Doctrine\Common\Inflector\Inflector;
 use Minetro\Normgen\Entity\Table;
 use Minetro\Normgen\Resolver\IFilenameResolver;
 use Minetro\Normgen\Utils\Helpers;
@@ -15,7 +16,7 @@ class SimpleTogetherResolver extends SimpleResolver
      */
     public function resolveEntityName(Table $table)
     {
-        return $this->normalize(ucfirst($table->getName()) . $this->config->get('entity.name.suffix'));
+		return $this->resolveName('entity', $table);
     }
 
     /**
@@ -24,7 +25,7 @@ class SimpleTogetherResolver extends SimpleResolver
      */
     public function resolveEntityNamespace(Table $table)
     {
-        return $this->config->get('orm.namespace') . Helpers::NS . $this->table($table);
+        return $this->config->get('orm.namespace') . Helpers::NS . $this->table($table, $this->config->get('orm.singularize'));
     }
 
     /**
@@ -33,8 +34,8 @@ class SimpleTogetherResolver extends SimpleResolver
      */
     public function resolveEntityFilename(Table $table)
     {
-        return $this->table($table) . Helpers::DS . $this->normalize(ucfirst($table->getName()) . $this->config->get('entity.filename.suffix')) . '.' . IFilenameResolver::PHP_EXT;
-    }
+		return $this->resolveFilenameFor('entity', $table);
+     }
 
     /**
      * @param Table $table
@@ -42,7 +43,7 @@ class SimpleTogetherResolver extends SimpleResolver
      */
     public function resolveRepositoryName(Table $table)
     {
-        return $this->normalize(ucfirst($table->getName()) . $this->config->get('repository.name.suffix'));
+		return $this->resolveName('repository', $table);
     }
 
     /**
@@ -60,7 +61,7 @@ class SimpleTogetherResolver extends SimpleResolver
      */
     public function resolveRepositoryFilename(Table $table)
     {
-        return $this->table($table) . Helpers::DS . $this->normalize(ucfirst($table->getName()) . $this->config->get('repository.filename.suffix')) . '.' . IFilenameResolver::PHP_EXT;
+        return $this->resolveFilenameFor('repository', $table);
     }
 
     /**
@@ -69,7 +70,7 @@ class SimpleTogetherResolver extends SimpleResolver
      */
     public function resolveMapperName(Table $table)
     {
-        return $this->normalize(ucfirst($table->getName()) . $this->config->get('mapper.name.suffix'));
+		return $this->resolveName('mapper', $table);
     }
 
     /**
@@ -78,7 +79,7 @@ class SimpleTogetherResolver extends SimpleResolver
      */
     public function resolveMapperNamespace(Table $table)
     {
-        return $this->config->get('orm.namespace') . Helpers::NS . $this->table($table);
+        return $this->config->get('orm.namespace') . Helpers::NS . $this->table($table, $this->config->get('orm.singularize'));
     }
 
     /**
@@ -87,7 +88,7 @@ class SimpleTogetherResolver extends SimpleResolver
      */
     public function resolveMapperFilename(Table $table)
     {
-        return $this->table($table) . Helpers::DS . $this->normalize(ucfirst($table->getName()) . $this->config->get('mapper.filename.suffix')) . '.' . IFilenameResolver::PHP_EXT;
+        return $this->resolveFilenameFor('mapper', $table);
     }
 
     /**
@@ -96,8 +97,39 @@ class SimpleTogetherResolver extends SimpleResolver
      */
     public function resolveFacadeName(Table $table)
     {
-        return $this->normalize(ucfirst($table->getName()) . $this->config->get('facade.name.suffix'));
+    	return $this->resolveName('facade', $table);
     }
+
+	/**
+	 * @param string $type (entity,repository,mapper,facade)
+	 * @param $table
+	 * @return string
+	 */
+    protected function resolveName($type, Table $table)
+	{
+		$name = ucfirst($table->getName());
+		if($this->config->get($type . '.name.singularize')) {
+			$name = Inflector::singularize($name);
+		}
+		$name .= $this->config->get( $type . '.name.suffix');
+		return $this->normalize($name);
+	}
+
+	/**
+	 * @param string $type
+	 * @param Table $table
+	 * @return string
+	 */
+	protected function resolveFilenameFor($type, Table $table)
+	{
+		$folder = $this->table($table, $this->config->get('orm.singularize'));
+		$name = ucfirst($table->getName());
+		if($this->config->get($type . '.name.singularize')) {
+			$name = Inflector::singularize($name);
+		}
+		$filename = $this->normalize($name . $this->config->get($type . '.filename.suffix')) . '.' . IFilenameResolver::PHP_EXT;
+		return $folder . Helpers::DS . $filename;
+	}
 
     /**
      * @param Table $table
@@ -114,7 +146,7 @@ class SimpleTogetherResolver extends SimpleResolver
      */
     public function resolveFacadeFilename(Table $table)
     {
-        return $this->table($table) . Helpers::DS . $this->normalize(ucfirst($table->getName()) . $this->config->get('facade.filename.suffix')) . '.' . IFilenameResolver::PHP_EXT;
+        return $this->resolveFilenameFor('facade', $table);
     }
 
 }


### PR DESCRIPTION
Converting plural table name to singular class names

for example you have table users in database, when running now it will create

```
Users 
UsersRepository 
UsersMapper
UsersFacade

```
This allows you to set on any type (repository/entity/mapper/facade)  conversion to singular.
If U choose singularize option for all then you'll get

```
User
UserRepository 
UserMapper
UserFacade
```

I'm using doctrine Inflector for converting plural form to singular