### PR TITLE
Fix invalid characters in ENUMs and set it upper case

### DIFF
--- a/src/Generator/Entity/Decorator/ColumnMapper.php
+++ b/src/Generator/Entity/Decorator/ColumnMapper.php
@@ -32,7 +32,7 @@ class ColumnMapper implements IDecorator
 			case ColumnTypes::TYPE_ENUM:
 				foreach ($column->getEnum() as $enum) {
 					// Replace all character which are not in Helpers::PHP_IDENT
-					$enum = Strings::replace ($enum, '/[^a-zA-Z0-9_\x7f-\xff]*/', '');
+					$enum = Strings::replace($enum, '/[^a-zA-Z0-9_\x7f-\xff]*/', '');
 					$enum = Strings::upper($enum);
 					$name = Strings::upper($column->getName()) . '_' . $enum;
 					$class->addConstant($name, $enum);

--- a/src/Generator/Entity/Decorator/ColumnMapper.php
+++ b/src/Generator/Entity/Decorator/ColumnMapper.php
@@ -31,6 +31,9 @@ class ColumnMapper implements IDecorator
 			// Map: Enum
 			case ColumnTypes::TYPE_ENUM:
 				foreach ($column->getEnum() as $enum) {
+					// Replace all character which are not in Helpers::PHP_IDENT
+					$enum = Strings::replace ($enum, '/[^a-zA-Z0-9_\x7f-\xff]*/', '');
+					$enum = Strings::upper($enum);
 					$name = Strings::upper($column->getName()) . '_' . $enum;
 					$class->addConstant($name, $enum);
 				}


### PR DESCRIPTION
When ENUM contains dast `-` (like `czech-export`), generator fail with fatal error.

