### PR TITLE
PHP 8.1 incompability for Separed/Together configuration

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -139,7 +139,7 @@ class Config implements ArrayAccess
 	 * @return mixed
 	 * @throws InvalidStateException
 	 */
-	public function offsetGet($offset)
+	public function offsetGet($offset): mixed
 	{
 		if ($this->offsetExists($offset)) {
 			return $this->config[$offset];


### PR DESCRIPTION
Deprecated: Return type of Contributte\Nextras\Orm\Generator\Config\Config::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used t
o temporarily suppress the notice in C:\...\home\vendor\contributte\nextras-orm-generator\src\Config\Config.php on line 142