### PR TITLE
Resolve #37

### DIFF
--- a/src/Entity/PhpRelDoc.php
+++ b/src/Entity/PhpRelDoc.php
@@ -12,17 +12,17 @@ class PhpRelDoc
 	public const ASC = 1;
 	public const DESC = 2;
 
-	private ?string $type;
+	private ?string $type = null;
 
-	private ?string $entity;
+	private ?string $entity = null;
 
-	private ?string $variable;
+	private ?string $variable = null;
 
-	private ?bool $primary;
+	private ?bool $primary = null;
 
-	private ?string $orderProperty;
+	private ?string $orderProperty = null;
 
-	private ?int $orderDirection;
+	private ?int $orderDirection = null;
 
 	public function getType(): string
 	{


### PR DESCRIPTION
Initializes all nullable typed properties in PhpRelDoc with default null values. This prevents "must not be accessed before initialization" fatal errors when properties are checked (e.g., `$this->primary !== null`) before being set.

Fixes #37